### PR TITLE
Maven repository url change

### DIFF
--- a/amazonfreertossdk/build.gradle
+++ b/amazonfreertossdk/build.gradle
@@ -84,11 +84,11 @@ uploadArchives {
         mavenDeployer {
             beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
-            repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+            repository(url: "https://aws.oss.sonatype.org/service/local/staging/deploy/maven2/") {
                 authentication(userName: ossrhUsername, password: ossrhPassword)
             }
 
-            snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+            snapshotRepository(url: "https://aws.oss.sonatype.org/content/repositories/snapshots/") {
                 authentication(userName: ossrhUsername, password: ossrhPassword)
             }
 


### PR DESCRIPTION
Maven Repository url change to https://aws.oss.sonatype.org for releasing the sdk.

*Description of changes:*
The new url for future releases of sdk is https://aws.oss.sonatype.org

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
