### PR TITLE
Make WiFi access point security values consistent with FreeRTOS

### DIFF
--- a/app/src/main/java/software/amazon/freertos/demo/WifiInfo.java
+++ b/app/src/main/java/software/amazon/freertos/demo/WifiInfo.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 @Getter
 @Setter
 public class WifiInfo {
-    private static String[] NETWORK_TYPES = {"Open", "WEP", "WPA", "WPA2", "Other"};
+    private static String[] NETWORK_TYPES = {"Open", "WEP", "WPA", "WPA2", "WPA2-Enterprise", "Other"};
     private String ssid;
     private byte[] bssid;
     private int rssi;


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
There is a mismatch between the access point security type enum [values](https://github.com/aws/amazon-freertos/blob/master/libraries/abstractions/wifi/include/iot_wifi.h#L62) sent from the FreeRTOS device and the enum values expected by the mobile SDK. 
An unexpected enum type received from the device results in an out of bound exception when it is used as an array index. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
