### PR TITLE
Fix exception while unregistering broadcast receiver

### DIFF
--- a/amazonfreertossdk/src/main/java/software/amazon/freertos/amazonfreertossdk/AmazonFreeRTOSDevice.java
+++ b/amazonfreertossdk/src/main/java/software/amazon/freertos/amazonfreertossdk/AmazonFreeRTOSDevice.java
@@ -167,11 +167,23 @@ public class AmazonFreeRTOSDevice {
         mRxLargeObject = null;
         mTotalPackets = 0;
         mPacketCount = 1;
-        mContext.unregisterReceiver(mBondStateBroadcastReceiver);
+
+
         if (mBluetoothGatt != null) {
             mBluetoothGatt.close();
             mBluetoothGatt = null;
         }
+
+        /**
+         * Unregister the broadcast server. Logs a warning
+         * if the broadcast receiver is not registered yet.
+         */
+        try {
+            mContext.unregisterReceiver(mBondStateBroadcastReceiver);
+        } catch( IllegalArgumentException ex ) {
+            Log.w(TAG, "Failed to unregister broadcast receiver: ",  ex);
+        }
+
         // If ble connection is closed, there's no need to keep mqtt connection open.
         if (mMqttConnectionState != AmazonFreeRTOSConstants.MqttConnectionState.MQTT_Disconnected) {
             disconnectFromIot();


### PR DESCRIPTION
*Issue #, if available:*
Fixes #13 

*Description of changes:*
disconnect() method in AmazonFreeRTOSDevice unregisters the broadcast receiver, which gets registered only on a valid connection. It throws an exception if the disconnect() is invoked before a valid connection is made.

Fix: Catch not registered exception while unregistering broadcast receiver. 
Also moved gattclient.close() to first method being invoked.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
