### PR TITLE
Add empty user name and password

### DIFF
--- a/amazonfreertossdk/gradle.properties
+++ b/amazonfreertossdk/gradle.properties
@@ -10,3 +10,5 @@ developerId=amazon freertos
 developerName=FreeRTOS
 developerEmail=aws-iot-device-ble@amazon.com
 gitUrl=https://github.com/aws/amazon-freertos-ble-android-sdk.git
+ossrhUsername=
+ossrhPassword=


### PR DESCRIPTION
*Issue #, if available:*
Local build for SDK fails since there is no OSSRH user name and password.

*Description of changes:*
Added empty username and password properties to android sdk gradle.properties.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
