### PR TITLE
Send error codes to MCU

### DIFF
--- a/amazonfreertossdk/src/main/java/software/amazon/freertos/amazonfreertossdk/AmazonFreeRTOSConstants.java
+++ b/amazonfreertossdk/src/main/java/software/amazon/freertos/amazonfreertossdk/AmazonFreeRTOSConstants.java
@@ -81,7 +81,8 @@ public class AmazonFreeRTOSConstants {
         BLE_NO_ERROR,
         BLE_DISCONNECTED_ERROR,
         BLE_EMPTY_BROKER_ENDPOINT,
-        BLE_EMPTY_MQTT_CLIENT_ID
+        BLE_EMPTY_MQTT_CLIENT_ID,
+        BLE_COGNITO_AUTH_FAIL
     }
 
     /**

--- a/amazonfreertossdk/src/main/java/software/amazon/freertos/amazonfreertossdk/AmazonFreeRTOSConstants.java
+++ b/amazonfreertossdk/src/main/java/software/amazon/freertos/amazonfreertossdk/AmazonFreeRTOSConstants.java
@@ -78,7 +78,10 @@ public class AmazonFreeRTOSConstants {
     }
 
     public enum AmazonFreeRTOSError {
-        BLE_DISCONNECTED_ERROR
+        BLE_NO_ERROR,
+        BLE_DISCONNECTED_ERROR,
+        BLE_EMPTY_BROKER_ENDPOINT,
+        BLE_EMPTY_MQTT_CLIENT_ID
     }
 
     /**

--- a/amazonfreertossdk/src/main/java/software/amazon/freertos/amazonfreertossdk/AmazonFreeRTOSManager.java
+++ b/amazonfreertossdk/src/main/java/software/amazon/freertos/amazonfreertossdk/AmazonFreeRTOSManager.java
@@ -51,6 +51,7 @@ public class AmazonFreeRTOSManager {
     private Handler mScanHandler;
     private HandlerThread mScanHandlerThread;
     private boolean mScanning = false;
+    private boolean mCognitoSucceeded = true;
 
     private BluetoothAdapter mBluetoothAdapter;
     private BluetoothLeScanner mBluetoothLeScanner;
@@ -194,6 +195,7 @@ public class AmazonFreeRTOSManager {
         AmazonFreeRTOSDevice aDevice = new AmazonFreeRTOSDevice(btDevice, mContext, cp);
         mAFreeRTOSDevices.put(btDevice.getAddress(), aDevice);
         aDevice.connect(connectionStatusCallback, autoReconnect);
+        aDevice.setCognitoSucceeded(mCognitoSucceeded);
         return aDevice;
     }
 
@@ -213,6 +215,7 @@ public class AmazonFreeRTOSManager {
         AmazonFreeRTOSDevice aDevice = new AmazonFreeRTOSDevice(btDevice, mContext, ks);
         mAFreeRTOSDevices.put(btDevice.getAddress(), aDevice);
         aDevice.connect(connectionStatusCallback, autoReconnect);
+        aDevice.setCognitoSucceeded(mCognitoSucceeded);
         return aDevice;
     }
 
@@ -234,5 +237,15 @@ public class AmazonFreeRTOSManager {
      */
     public AmazonFreeRTOSDevice getConnectedDevice(String macAddr) {
         return mAFreeRTOSDevices.get(macAddr);
+    }
+
+    /**
+    *  All wifi-proxied devices depend on whether this phone is cognito authenticated
+    *
+    * @param status true if cognito succeeded else false
+    */
+    public void setCognitoSucceeded( boolean status )
+    {
+        mCognitoSucceeded = status;
     }
 }

--- a/app/src/main/java/software/amazon/freertos/demo/AuthenticatorActivity.java
+++ b/app/src/main/java/software/amazon/freertos/demo/AuthenticatorActivity.java
@@ -19,6 +19,8 @@ import com.amazonaws.services.iot.model.AttachPolicyRequest;
 
 import java.util.concurrent.CountDownLatch;
 
+import software.amazon.freertos.amazonfreertossdk.AmazonFreeRTOSManager;
+
 public class AuthenticatorActivity extends AppCompatActivity {
     private final static String TAG = "AuthActivity";
     private HandlerThread handlerThread;
@@ -103,6 +105,9 @@ public class AuthenticatorActivity extends AppCompatActivity {
     }
 
     private void signinsuccessful() {
+        /* Manager singleton is initialized before this call. Querying null returns existing handle */
+        AmazonFreeRTOSManager mAFRManager = AmazonFreeRTOSAgent.getAmazonFreeRTOSManager(null);
+
         try {
             AWSCredentialsProvider credentialsProvider = AWSMobileClient.getInstance();
             AWSIotClient awsIotClient = new AWSIotClient(credentialsProvider);
@@ -112,8 +117,10 @@ public class AuthenticatorActivity extends AppCompatActivity {
                     .withPolicyName(DemoConstants.AWS_IOT_POLICY_NAME)
                     .withTarget(AWSMobileClient.getInstance().getIdentityId());
             awsIotClient.attachPolicy(attachPolicyRequest);
+            mAFRManager.setCognitoSucceeded(true);
             Log.i(TAG, "Iot policy attached successfully.");
         } catch (Exception e) {
+            mAFRManager.setCognitoSucceeded(false);
             Log.e(TAG, "Exception caught: ", e);
         }
     }


### PR DESCRIPTION
Add mechanism to send 7-bit error codes to MCU device. Reports errors in upper 7-bits of existing CONTROL Gatt characteristic which previously only used the lowest bit. Now instead of cluelessly observing mqtt timeouts, the MCU can get a sense of what triggered that TIMEOUT from the peer's error codes.

There is a [companion PR](https://github.com/aws/amazon-freertos/pull/2305) in `amazon-freertos` for handling these error codes on MCU side.

**Side Note:**
Wanted to make full use of the exception reasons listed in `org.eclipse.paho.client.mqttv3.MqttException.java` and catch them in application layer but kept getting `REASON_CODE_CLIENT_EXCEPTION` claiming '_already connected_ 'despite adding triggers for other exception reasons, like deleting a policy that should be there. May be a separate issue, or I may need to look elsewhere in the code to retrieve that information.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
