### PR TITLE
Set delete/edit/save network resp classes as getters

### DIFF
--- a/amazonfreertossdk/src/main/java/software/amazon/freertos/amazonfreertossdk/networkconfig/DeleteNetworkResp.java
+++ b/amazonfreertossdk/src/main/java/software/amazon/freertos/amazonfreertossdk/networkconfig/DeleteNetworkResp.java
@@ -26,10 +26,12 @@ import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.Map;
 import co.nstant.in.cbor.model.UnicodeString;
 import co.nstant.in.cbor.model.UnsignedInteger;
+import lombok.Getter;
 
 /**
  * Delete network response
  */
+@Getter
 public class DeleteNetworkResp {
     /**
      * Status of the operation. 0 for success.

--- a/amazonfreertossdk/src/main/java/software/amazon/freertos/amazonfreertossdk/networkconfig/EditNetworkResp.java
+++ b/amazonfreertossdk/src/main/java/software/amazon/freertos/amazonfreertossdk/networkconfig/EditNetworkResp.java
@@ -26,10 +26,12 @@ import co.nstant.in.cbor.model.DataItem;
 import co.nstant.in.cbor.model.Map;
 import co.nstant.in.cbor.model.UnicodeString;
 import co.nstant.in.cbor.model.UnsignedInteger;
+import lombok.Getter;
 
 /**
  * Edit network response
  */
+@Getter
 public class EditNetworkResp {
     /**
      * Status of the operation. 0 for success.

--- a/amazonfreertossdk/src/main/java/software/amazon/freertos/amazonfreertossdk/networkconfig/SaveNetworkResp.java
+++ b/amazonfreertossdk/src/main/java/software/amazon/freertos/amazonfreertossdk/networkconfig/SaveNetworkResp.java
@@ -27,10 +27,12 @@ import co.nstant.in.cbor.model.Map;
 
 import co.nstant.in.cbor.model.UnicodeString;
 import co.nstant.in.cbor.model.UnsignedInteger;
+import lombok.Getter;
 
 /**
  * Save network response
  */
+@Getter
 public class SaveNetworkResp {
     /**
      * Status of the operation. 0 for success.


### PR DESCRIPTION
*Issue #, if available:* #32 

*Description of changes:*
Add `@Getter` annotation to `DeleteNetworkResp`, `EditNetworkResp` and `SaveNetworkResp` classes to enable `getStatus()` method.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
