### PR TITLE
WPA3 Wifi security enum fix

### DIFF
--- a/app/src/main/java/software/amazon/freertos/demo/WifiInfo.java
+++ b/app/src/main/java/software/amazon/freertos/demo/WifiInfo.java
@@ -8,7 +8,7 @@ import lombok.Setter;
 @Getter
 @Setter
 public class WifiInfo {
-    private static String[] NETWORK_TYPES = {"Open", "WEP", "WPA", "WPA2", "WPA2-Enterprise", "Other"};
+    private static String[] NETWORK_TYPES = {"Open", "WEP", "WPA", "WPA2", "WPA2-Enterprise", "WPA3", "Other"};
     private String ssid;
     private byte[] bssid;
     private int rssi;


### PR DESCRIPTION
*Description of changes:*
Fix Wifi security enum by adding "WPA3" 

In order to be synchronize with:
https://github.com/aws/amazon-freertos/blob/7128fe2a56ffeae331d783ee5ab7290fe1861ebc/libraries/abstractions/wifi/include/iot_wifi.h#L85
change by this commit:
https://github.com/aws/amazon-freertos/commit/6ed09c0a02e460cba7b500e5c5141fe2269721c1


Note: I would like to contact maintainers to talk about others improvements I'd like to push:
- upgrade to androidx
- migration to Fragment and single activity (and layout bindings)
- migration to Kotlin 
- usage of protobuf instead of Req/Resp classes
- ...
Are you interested in some of these developments?
