### PR TITLE
Add connect field to SaveNetworkReq

### DIFF
--- a/amazonfreertossdk/src/main/java/software/amazon/freertos/amazonfreertossdk/networkconfig/SaveNetworkReq.java
+++ b/amazonfreertossdk/src/main/java/software/amazon/freertos/amazonfreertossdk/networkconfig/SaveNetworkReq.java
@@ -49,6 +49,10 @@ public class SaveNetworkReq {
      * Current index of the network to be saved.
      */
     public int index;
+    /**
+     * Connect immediately or just save for later.
+     */
+    public boolean connect;
 
     private static final String TAG = "SaveNetworkRequest";
     private static final String INDEX_KEY = "g";
@@ -57,6 +61,7 @@ public class SaveNetworkReq {
     private static final String PSK_KEY = "m";
     private static final String SECURITY_KEY = "q";
     private static final String TYPE_KEY = "w";
+    private static final String CONNECT_KEY = "y";
 
     public byte[] encode() {
         byte[] SaveNetworkRequestBytes = null;
@@ -70,6 +75,7 @@ public class SaveNetworkReq {
                     .put(BSSID_KEY, bssid)
                     .put(PSK_KEY, psk)
                     .put(SECURITY_KEY, security)
+                    .put(CONNECT_KEY, connect)
                     .end()
                     .build());
             SaveNetworkRequestBytes = baos.toByteArray();

--- a/amazonfreertossdk/src/main/java/software/amazon/freertos/amazonfreertossdk/networkconfig/SaveNetworkReq.java
+++ b/amazonfreertossdk/src/main/java/software/amazon/freertos/amazonfreertossdk/networkconfig/SaveNetworkReq.java
@@ -52,7 +52,7 @@ public class SaveNetworkReq {
     /**
      * Connect immediately or just save for later.
      */
-    public boolean connect;
+    public boolean connect = true;
 
     private static final String TAG = "SaveNetworkRequest";
     private static final String INDEX_KEY = "g";


### PR DESCRIPTION
In the iOS SDK `SaveNetworkReq` includes a `connect` parameter which is missing in the Android SDK's `SaveNetworkReq`.

The iOS version of SaveNetworkReq: https://github.com/aws/amazon-freertos-ble-ios-sdk/blob/master/AmazonFreeRTOS/Services/NetworkConfig/SaveNetworkReq.swift#L12

The `connect` parameter is encoded with a "y": https://github.com/aws/amazon-freertos-ble-ios-sdk/blob/master/AmazonFreeRTOS/AmazonFreeRTOSEnums.swift#L129-L130


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
